### PR TITLE
create project-level out/ directory in build.sh with mkdir -p

### DIFF
--- a/contracts/rust/build.sh
+++ b/contracts/rust/build.sh
@@ -2,4 +2,5 @@
 set -e
 
 RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release
+mkdir -p ../../out
 cp target/wasm32-unknown-unknown/release/*.wasm ../../out/


### PR DESCRIPTION
Tiny PR to make the `out/` directory if it's not there, otherwise the copy fails