### PR TITLE
Finalize readmes for nfts: rust implementation description, nodejs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Rust
 If you are using Gitpod, you can skip this section! Your environment is already set up 🎉
 
   * Make sure Rust is installed per the prerequisites in [`near-sdk-rs`](https://github.com/nearprotocol/near-sdk-rs)
-  * Make sure you have Node.js ≥ 12 installed,  then use it to install [yarn]: `npm install --global yarn` (or just `npm i -g yarn`)
+  * Make sure you have Node.js ≥ 12 installed (https://nodejs.org),  then use it to install [yarn]: `npm install --global yarn` (or just `npm i -g yarn`)
   * Install dependencies: `yarn install` (or just `yarn`) 
 
 2. Explore this contract
@@ -45,8 +45,7 @@ _Using Gitpod? You can skip these setup steps!_
 
 To run this project locally:
 
-1. Prerequisites: Make sure you have Node.js ≥ 12 installed, then use it to install [yarn]: `npm install --global yarn` (or just
-   `npm i -g yarn`)
+1. Prerequisites: Make sure you have Node.js ≥ 12 installed (https://nodejs.org), then use it to install [yarn]: `npm install --global yarn` (or just `npm i -g yarn`)
 2. Install dependencies: `yarn install` (or just `yarn`)
 
 Now you can run all the [AssemblyScript]-related scripts listed in `package.json`! Scripts you might want to start with:

--- a/contracts/rust/README.md
+++ b/contracts/rust/README.md
@@ -1,0 +1,23 @@
+Minimal NEP#4 Implementation
+============================
+
+This contract implements bare-minimum functionality to satisfy the [NEP#4](https://github.com/nearprotocol/NEPs/pull/4) specification
+
+
+Notable limitations of this implementation
+==========================================
+
+* Anyone can mint tokens (!!) until the supply is maxed out
+* You cannot give another account escrow access to a limited set of your tokens; an escrow must be trusted with all of your tokens or none at all
+* No functions to return the maximum or current supply of tokens
+* No functions to return metadata such as the name or symbol of this NFT
+* No functions (or storage primitives) to find all tokens belonging to a given account
+* Usability issues: some functions (`revoke_access`, `transfer`, `get_token_owner`) do not verify that they were given sensible inputs; if given non-existent keys, the errors they throw will not be very useful
+
+Still, if you track some of this information in an off-chain database, these limitations may be acceptable for your needs. In that case, this implementation may help reduce gas and storage costs.
+
+
+Notable additions that go beyond the specification of NEP#4
+===========================================================
+
+`mint_token`: the spec gives no guidance or requirements on how tokens are minted/created/assigned. If this implementation of `mint_token` is close to matching your needs, feel free to ship your NFT with only minor modifications (such as caller verification). If you'd rather go with a strategy such as minting the whole supply of tokens upon deploy of the contract, or something else entirely, you may want to drastically change this behavior.

--- a/contracts/rust/README.md
+++ b/contracts/rust/README.md
@@ -7,12 +7,12 @@ This contract implements bare-minimum functionality to satisfy the [NEP#4](https
 Notable limitations of this implementation
 ==========================================
 
-* Anyone can mint tokens (!!) until the supply is maxed out
+* Only the token owner can mint tokens.
 * You cannot give another account escrow access to a limited set of your tokens; an escrow must be trusted with all of your tokens or none at all
 * No functions to return the maximum or current supply of tokens
 * No functions to return metadata such as the name or symbol of this NFT
 * No functions (or storage primitives) to find all tokens belonging to a given account
-* Usability issues: some functions (`revoke_access`, `transfer`, `get_token_owner`) do not verify that they were given sensible inputs; if given non-existent keys, the errors they throw will not be very useful
+* Usability issues: some functions (e.g. `revoke_access`, `transfer`, `get_token_owner`) do not verify that they were given sensible inputs; if given non-existent keys, the errors they throw will not be very useful
 
 Still, if you track some of this information in an off-chain database, these limitations may be acceptable for your needs. In that case, this implementation may help reduce gas and storage costs.
 

--- a/contracts/rust/README.md
+++ b/contracts/rust/README.md
@@ -20,4 +20,4 @@ Still, if you track some of this information in an off-chain database, these lim
 Notable additions that go beyond the specification of NEP#4
 ===========================================================
 
-`mint_token`: the spec gives no guidance or requirements on how tokens are minted/created/assigned. If this implementation of `mint_token` is close to matching your needs, feel free to ship your NFT with only minor modifications (such as caller verification). If you'd rather go with a strategy such as minting the whole supply of tokens upon deploy of the contract, or something else entirely, you may want to drastically change this behavior.
+`mint_token`: the spec gives no guidance or requirements on how tokens are minted/created/assigned. This specific implementation only allows the contract owner to mint new tokens. If this implementation of `mint_token` is close to matching your needs, feel free to ship your NFT with only minor modifications. If you'd rather go with a strategy such as minting the whole supply of tokens upon deploy of the contract, or something else entirely, you may want to drastically change this behavior.


### PR DESCRIPTION
The rust implementation README file is mostly a copy a similar file from
assemblyscript, with only a few changes to address differences in
implementation (different function for minting, and the ability of grant
escrow access to multiple accounts in rust)

This PR also contains a drive-by fix of adding a url for nodejs in the
prereqs section