### PR TITLE
Update rust contract to have both transfer and transfer_from

### DIFF
--- a/contracts/assemblyscript/nep4-basic/__tests__/main.unit.spec.ts
+++ b/contracts/assemblyscript/nep4-basic/__tests__/main.unit.spec.ts
@@ -59,7 +59,7 @@ describe('revoke_access', () => {
   })
 })
 
-describe('transfer', () => {
+describe('transfer_from', () => {
   it('allows owner to transfer_from given `token_id` to given `owner_id`', () => {
     // Alice has a token
     const aliceToken = nonSpec.mint_to(alice)
@@ -69,21 +69,6 @@ describe('transfer', () => {
     // Alice transfers her token to Bob
     Context.setPredecessor_account_id(alice)
     transfer_from(alice, bob, aliceToken)
-
-    // it works!
-    expect(get_token_owner(aliceToken)).toBe(bob)
-    expect(get_token_owner(aliceToken)).not.toBe(alice)
-  })
-
-  it('allows owner to transfer given `token_id` to given `owner_id`', () => {
-    // Alice has a token
-    const aliceToken = nonSpec.mint_to(alice)
-    expect(get_token_owner(aliceToken)).toBe(alice)
-    expect(get_token_owner(aliceToken)).not.toBe(bob)
-
-    // Alice transfers her token to Bob
-    Context.setPredecessor_account_id(alice)
-    transfer(bob, aliceToken)
 
     // it works!
     expect(get_token_owner(aliceToken)).toBe(bob)
@@ -126,6 +111,34 @@ describe('transfer', () => {
     }).toThrow(nonSpec.ERROR_OWNER_ID_DOES_NOT_MATCH_EXPECTATION)
   })
 
+  it('prevents anyone else from using transfer_from on the token', () => {
+    expect(() => {
+      // Alice has a token
+      const aliceToken = nonSpec.mint_to(alice)
+
+      // Bob tries to transfer it to himself
+      Context.setPredecessor_account_id(bob)
+      transfer_from(alice, bob, aliceToken)
+    }).toThrow(nonSpec.ERROR_CALLER_ID_DOES_NOT_MATCH_EXPECTATION)
+  })
+})
+
+describe('transfer', () => {
+  it('allows owner to transfer given `token_id` to given `owner_id`', () => {
+    // Alice has a token
+    const aliceToken = nonSpec.mint_to(alice)
+    expect(get_token_owner(aliceToken)).toBe(alice)
+    expect(get_token_owner(aliceToken)).not.toBe(bob)
+
+    // Alice transfers her token to Bob
+    Context.setPredecessor_account_id(alice)
+    transfer(bob, aliceToken)
+
+    // it works!
+    expect(get_token_owner(aliceToken)).toBe(bob)
+    expect(get_token_owner(aliceToken)).not.toBe(alice)
+  })
+  
   it('prevents escrow from using transfer. Escrow can only use transfer_from', () => {
     expect(() => {
       // Alice grants access to Bob
@@ -142,18 +155,8 @@ describe('transfer', () => {
       transfer(carol, aliceToken)
     }).toThrow(nonSpec.ERROR_TOKEN_NOT_OWNED_BY_CALLER)
   })
-
-  it('prevents anyone else from using transfer_from on the token', () => {
-    expect(() => {
-      // Alice has a token
-      const aliceToken = nonSpec.mint_to(alice)
-
-      // Bob tries to transfer it to himself
-      Context.setPredecessor_account_id(bob)
-      transfer_from(alice, bob, aliceToken)
-    }).toThrow(nonSpec.ERROR_CALLER_ID_DOES_NOT_MATCH_EXPECTATION)
-  })
 })
+
 
 describe('check_access', () => {
   it('returns true if caller of the function has access to the token', () => {

--- a/contracts/assemblyscript/nep4-basic/main.ts
+++ b/contracts/assemblyscript/nep4-basic/main.ts
@@ -31,6 +31,8 @@ const TOTAL_SUPPLY = 'c'
 export const ERROR_NO_ESCROW_REGISTERED = 'Caller has no escrow registered'
 export const ERROR_CALLER_ID_DOES_NOT_MATCH_EXPECTATION = 'Caller ID does not match expectation'
 export const ERROR_MAXIMUM_TOKEN_LIMIT_REACHED = 'Maximum token limit reached'
+export const ERROR_OWNER_ID_DOES_NOT_MATCH_EXPECTATION = 'Owner id does not match real token owner id'
+export const ERROR_TOKEN_NOT_OWNED_BY_CALLER = 'Token is not owned by the caller. Please use transfer_from for this scenario'
 
 /******************/
 /* CHANGE METHODS */
@@ -46,20 +48,41 @@ export function revoke_access(escrow_account_id: string): void {
   escrowAccess.delete(context.predecessor)
 }
 
-// Transfer the given `token_id` to the given `new_owner_id`. Account `new_owner_id` becomes the new owner
+// Transfer the given `tokenId` to the given `accountId`.  Account `accountId` becomes the new owner.
 // Requirements:
-// * The caller of the function (`predecessor`) should own or have access to the token
-export function transfer(new_owner_id: string, token_id: TokenId): void {
+// * The caller of the function (`predecessor_id`) should have access to the token.
+// * owner_id must actually own the token.
+export function transfer_from(owner_id: string, new_owner_id: string, token_id: TokenId): void {
   const predecessor = context.predecessor
 
   // fetch token owner and escrow; assert access
   const owner = tokenToOwner.getSome(token_id)
+  assert(owner == owner_id, ERROR_OWNER_ID_DOES_NOT_MATCH_EXPECTATION)
   const escrow = escrowAccess.get(owner)
   assert([owner, escrow].includes(predecessor), ERROR_CALLER_ID_DOES_NOT_MATCH_EXPECTATION)
 
   // assign new owner to token
   tokenToOwner.set(token_id, new_owner_id)
 }
+
+
+// Transfer the given `tokenId` to the given `accountId`.  Account `accountId` becomes the new owner.
+// Requirements:
+// * The caller of the function (`predecessor_id`) should be the owner of the token. Callers who have
+// escrow access should use transfer_from.
+export function transfer(new_owner_id: string, token_id: TokenId): void {
+  const predecessor = context.predecessor
+
+  // fetch token owner and escrow; assert access
+  const owner = tokenToOwner.getSome(token_id)
+  assert(owner == predecessor, ERROR_TOKEN_NOT_OWNED_BY_CALLER)
+  const escrow = escrowAccess.get(owner)
+  assert([owner, escrow].includes(predecessor), ERROR_CALLER_ID_DOES_NOT_MATCH_EXPECTATION)
+
+  // assign new owner to token
+  tokenToOwner.set(token_id, new_owner_id)
+}
+
 
 /****************/
 /* VIEW METHODS */

--- a/contracts/assemblyscript/nep4-basic/main.ts
+++ b/contracts/assemblyscript/nep4-basic/main.ts
@@ -48,10 +48,9 @@ export function revoke_access(escrow_account_id: string): void {
   escrowAccess.delete(context.predecessor)
 }
 
-// Transfer the given `tokenId` to the given `accountId`.  Account `accountId` becomes the new owner.
+// Transfer the given `token_id` to the given `new_owner_id`. Account `new_owner_id` becomes the new owner.
 // Requirements:
-// * The caller of the function (`predecessor_id`) should have access to the token.
-// * owner_id must actually own the token.
+// * The caller of the function (`predecessor`) should have access to the token.
 export function transfer_from(owner_id: string, new_owner_id: string, token_id: TokenId): void {
   const predecessor = context.predecessor
 
@@ -66,9 +65,9 @@ export function transfer_from(owner_id: string, new_owner_id: string, token_id: 
 }
 
 
-// Transfer the given `tokenId` to the given `accountId`.  Account `accountId` becomes the new owner.
+// Transfer the given `token_id` to the given `new_owner_id`. Account `new_owner_id` becomes the new owner.
 // Requirements:
-// * The caller of the function (`predecessor_id`) should be the owner of the token. Callers who have
+// * The caller of the function (`predecessor`) should be the owner of the token. Callers who have
 // escrow access should use transfer_from.
 export function transfer(new_owner_id: string, token_id: TokenId): void {
   const predecessor = context.predecessor
@@ -76,8 +75,6 @@ export function transfer(new_owner_id: string, token_id: TokenId): void {
   // fetch token owner and escrow; assert access
   const owner = tokenToOwner.getSome(token_id)
   assert(owner == predecessor, ERROR_TOKEN_NOT_OWNED_BY_CALLER)
-  const escrow = escrowAccess.get(owner)
-  assert([owner, escrow].includes(predecessor), ERROR_CALLER_ID_DOES_NOT_MATCH_EXPECTATION)
 
   // assign new owner to token
   tokenToOwner.set(token_id, new_owner_id)

--- a/contracts/rust/src/lib.rs
+++ b/contracts/rust/src/lib.rs
@@ -382,4 +382,22 @@ mod tests {
         testing_env!(context);
         contract.transfer(joe(), token_id.clone());
     }
+
+    #[test]
+    fn transfer_with_your_own_token() {
+        // Owner account: robert.testnet
+        // New owner account: joe.testnet
+
+        testing_env!(get_context(robert(), 0));
+        let mut contract = NonFungibleTokenBasic::new(robert());
+        let token_id = 19u64;
+        contract.mint_token(robert(), token_id);
+
+        // Robert transfers the token to Joe
+        contract.transfer(joe(), token_id.clone());
+
+        // Check new owner
+        let owner = contract.get_token_owner(token_id.clone());
+        assert_eq!(joe(), owner, "Token was not transferred after transfer call with escrow.");
+    }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:unit:rs": "(cd contracts/rust && cargo test -- --nocapture --color always)"
   },
   "devDependencies": {
-    "assemblyscript": "^0.10.0",
+    "assemblyscript": "^0.9.4",
     "jest": "^25.5.4",
     "near-sdk-as": "^0.3.3",
     "near-shell": "^0.24.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,12 +893,12 @@ assemblyscript-json@^0.3.0:
   resolved "https://registry.yarnpkg.com/assemblyscript-json/-/assemblyscript-json-0.3.0.tgz#f44e4001ecf8db5816bf74d2ef34868ec80e2867"
   integrity sha512-CW05xrcMQ2mQUXj84Nq8KESyMHn5x+Z4NUwRQveUhWpWwPu7zp8oLNMLb5lKJ8CgRXmE8lxYSfe3/867sN+qRA==
 
-assemblyscript@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.10.0.tgz#0d2a0591be77fdd294d720172e307e526a559ba8"
-  integrity sha512-ErUNhHboD+zsB4oG6X1YICDAIo27Gq7LeNX6jVe+Q0W5cI51/fHwC8yJ68IukqvupmZgYPdp1JqqRXlS+BrUfA==
+assemblyscript@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.9.4.tgz#d535ad6e9299c9d3b9881ff08c3101298d53cb1a"
+  integrity sha512-GabjIxYt5uI3nyZNYzw6VtHyZcjVtcw8tbtEbXGvbrp3+A5p3zQ2yrU03tSiRR+WTeGx2aS8c6T+y2gGfjyvqw==
   dependencies:
-    binaryen "93.0.0-nightly.20200514"
+    binaryen "91.0.0-nightly.20200310"
     long "^4.0.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
@@ -1050,10 +1050,10 @@ binary-install@^0.0.1:
     tar "^5.0.5"
     universal-url "^2.0.0"
 
-binaryen@93.0.0-nightly.20200514:
-  version "93.0.0-nightly.20200514"
-  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-93.0.0-nightly.20200514.tgz#af498b5d9f8169254fb0cd385061d94ba9b27b1d"
-  integrity sha512-SRRItmNvhRVfoWWbRloO4i8IqkKH8rZ7/0QWRgLpM3umupK8gBpo9MY7Zp3pDysRSp+rVoqxvM5x4tFyCSa9zw==
+binaryen@91.0.0-nightly.20200310:
+  version "91.0.0-nightly.20200310"
+  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-91.0.0-nightly.20200310.tgz#f2c60020fef1fb5ac0e436b9a0e01b25c484c0b4"
+  integrity sha512-MmDzq267aa61HdEQeYiz+7guJlsYk2/6NxWC8I4w1jijqDwoqyZZxi7UYnTH7QvfLrNdMjweEgfT7FHjkvkPmQ==
 
 bindings@^1.4.0, bindings@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
Only transfer_from can be used by escrow accounts. transfer_from verifies that the real token owner matches the passed in owner_id in order to avoid race conditions in escrow transfers.