### PR TITLE
refactor: add AS to CI; rm simulation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_install:
   - export PATH="$HOME/.cargo/bin:$PATH"
   - rustup target add wasm32-unknown-unknown
 script:
-  - npm run test:unit:rs
+  - npm run test

--- a/package.json
+++ b/package.json
@@ -9,12 +9,9 @@
     "build:as": "node ./contracts/assemblyscript/compile.js",
     "build:rs": "(cd contracts/rust && ./build.sh)",
     "clean": "rm -rf ./out && (cd contracts/rust && cargo clean)",
-    "test": "yarn test:unit",
-    "test:all": "yarn test && yarn test:simulate:runtime",
-    "test:unit": "yarn test:unit:as && yarn test:unit:rs",
+    "test": "yarn test:unit:as && yarn test:unit:rs",
     "test:unit:as": "asp --verbose --nologo -c contracts/assemblyscript/as-pect.config.js -f unit.spec",
-    "test:unit:rs": "(cd contracts/rust && cargo test -- --nocapture --color always)",
-    "test:simulate:runtime": "jest --verbose -f simulate.spec"
+    "test:unit:rs": "(cd contracts/rust && cargo test -- --nocapture --color always)"
   },
   "devDependencies": {
     "assemblyscript": "^0.9.4",


### PR DESCRIPTION
Partially addresses #28 

* We are not using simulation tests yet; let's remove related commands from package.json
* Make sure CI runs all tests, not just Rust