### PR TITLE
fix tests for assemblyscript / rust

### DIFF
--- a/contracts/assemblyscript/nep4-basic/__tests__/main.unit.spec.ts
+++ b/contracts/assemblyscript/nep4-basic/__tests__/main.unit.spec.ts
@@ -1,4 +1,4 @@
-import { VM, Context } from 'near-sdk-as'
+import { VMContext } from 'near-sdk-as'
 
 // explicitly import functions required by spec
 import {
@@ -24,11 +24,11 @@ describe('grant_access', () => {
     const aliceToken = nonSpec.mint_to(alice)
 
     // Alice calls `grant_access` to make Bob her escrow
-    Context.setPredecessor_account_id(alice)
+    VMContext.setPredecessor_account_id(alice)
     grant_access(bob)
 
     // Bob checks if Alice has done so
-    Context.setPredecessor_account_id(bob)
+    VMContext.setPredecessor_account_id(bob)
     expect(check_access(alice)).toBe(true)
   })
 })
@@ -36,25 +36,25 @@ describe('grant_access', () => {
 describe('revoke_access', () => {
   it('revokes access to the given `accountId` for the given `tokenId`', () => {
     // Prevent error `InconsistentStateError(IntegerOverflow)` thrown by near-sdk-rs
-    Context.setStorage_usage(100)
+    VMContext.setStorage_usage(100)
 
     // Alice has a token
     const aliceToken = nonSpec.mint_to(alice)
 
     // Alice makes Bob her escrow
-    Context.setPredecessor_account_id(alice)
+    VMContext.setPredecessor_account_id(alice)
     grant_access(bob)
 
     // Bob checks if he has access to Alice's account
-    Context.setPredecessor_account_id(bob)
+    VMContext.setPredecessor_account_id(bob)
     expect(check_access(alice)).toBe(true)
 
     // Alice revokes Bob's access
-    Context.setPredecessor_account_id(alice)
+    VMContext.setPredecessor_account_id(alice)
     revoke_access(bob)
 
     // Bob checks again
-    Context.setPredecessor_account_id(bob)
+    VMContext.setPredecessor_account_id(bob)
     expect(check_access(alice)).toBe(false)
   })
 })
@@ -67,7 +67,7 @@ describe('transfer_from', () => {
     expect(get_token_owner(aliceToken)).not.toBe(bob)
 
     // Alice transfers her token to Bob
-    Context.setPredecessor_account_id(alice)
+    VMContext.setPredecessor_account_id(alice)
     transfer_from(alice, bob, aliceToken)
 
     // it works!
@@ -77,7 +77,7 @@ describe('transfer_from', () => {
 
   it('allows escrow to transfer given `token_id` to given `new_owner_id` if `owner_id` matches', () => {
     // Alice grants access to Bob
-    Context.setPredecessor_account_id(alice)
+    VMContext.setPredecessor_account_id(alice)
     grant_access(bob)
 
     // Alice has a token
@@ -86,7 +86,7 @@ describe('transfer_from', () => {
     expect(get_token_owner(aliceToken)).not.toBe(bob)
 
     // Bob transfers to himself
-    Context.setPredecessor_account_id(bob)
+    VMContext.setPredecessor_account_id(bob)
     transfer_from(alice, bob, aliceToken)
 
     // it works!
@@ -97,7 +97,7 @@ describe('transfer_from', () => {
   it('prevents escrow from transferring given `token_id` to given `new_owner_id if `owner_id` does not match`', () => {
     expect(() => {
       // Alice grants access to Bob
-      Context.setPredecessor_account_id(alice)
+      VMContext.setPredecessor_account_id(alice)
       grant_access(bob)
 
       // Alice has a token
@@ -106,7 +106,7 @@ describe('transfer_from', () => {
       expect(get_token_owner(aliceToken)).not.toBe(bob)
 
       // Bob attempts to transfer and has access, but owner_id is wrong
-      Context.setPredecessor_account_id(bob)
+      VMContext.setPredecessor_account_id(bob)
       transfer_from(bob, carol, aliceToken)
     }).toThrow(nonSpec.ERROR_OWNER_ID_DOES_NOT_MATCH_EXPECTATION)
   })
@@ -117,7 +117,7 @@ describe('transfer_from', () => {
       const aliceToken = nonSpec.mint_to(alice)
 
       // Bob tries to transfer it to himself
-      Context.setPredecessor_account_id(bob)
+      VMContext.setPredecessor_account_id(bob)
       transfer_from(alice, bob, aliceToken)
     }).toThrow(nonSpec.ERROR_CALLER_ID_DOES_NOT_MATCH_EXPECTATION)
   })
@@ -131,18 +131,18 @@ describe('transfer', () => {
     expect(get_token_owner(aliceToken)).not.toBe(bob)
 
     // Alice transfers her token to Bob
-    Context.setPredecessor_account_id(alice)
+    VMContext.setPredecessor_account_id(alice)
     transfer(bob, aliceToken)
 
     // it works!
     expect(get_token_owner(aliceToken)).toBe(bob)
     expect(get_token_owner(aliceToken)).not.toBe(alice)
   })
-  
+
   it('prevents escrow from using transfer. Escrow can only use transfer_from', () => {
     expect(() => {
       // Alice grants access to Bob
-      Context.setPredecessor_account_id(alice)
+      VMContext.setPredecessor_account_id(alice)
       grant_access(bob)
 
       // Alice has a token
@@ -151,7 +151,7 @@ describe('transfer', () => {
       expect(get_token_owner(aliceToken)).not.toBe(bob)
 
       // Bob attempts to transfer and has access, but owner_id is wrong
-      Context.setPredecessor_account_id(bob)
+      VMContext.setPredecessor_account_id(bob)
       transfer(carol, aliceToken)
     }).toThrow(nonSpec.ERROR_TOKEN_NOT_OWNED_BY_CALLER)
   })
@@ -159,7 +159,7 @@ describe('transfer', () => {
   it('prevents anyone else from transferring the token', () => {
     expect(() => {
       // Alice grants access to Bob
-      Context.setPredecessor_account_id(alice)
+      VMContext.setPredecessor_account_id(alice)
 
       // Alice has a token
       const aliceToken = nonSpec.mint_to(alice)
@@ -167,7 +167,7 @@ describe('transfer', () => {
       expect(get_token_owner(aliceToken)).not.toBe(bob)
 
       // Bob attempts to transfer and has access, but owner_id is wrong
-      Context.setPredecessor_account_id(bob)
+      VMContext.setPredecessor_account_id(bob)
       transfer(carol, aliceToken)
     }).toThrow(nonSpec.ERROR_TOKEN_NOT_OWNED_BY_CALLER)
   })
@@ -180,11 +180,11 @@ describe('check_access', () => {
     const aliceToken = nonSpec.mint_to(alice)
 
     // Alice grants access to Bob
-    Context.setPredecessor_account_id(alice)
+    VMContext.setPredecessor_account_id(alice)
     grant_access(bob)
 
     // Bob checks if he has access
-    Context.setPredecessor_account_id(bob)
+    VMContext.setPredecessor_account_id(bob)
     expect(check_access(alice)).toBe(true)
   })
 
@@ -193,7 +193,7 @@ describe('check_access', () => {
     const aliceToken = nonSpec.mint_to(alice)
 
     // Bob checks if he has access
-    Context.setPredecessor_account_id(alice)
+    VMContext.setPredecessor_account_id(alice)
     expect(check_access(bob)).toBe(false)
   })
 })
@@ -219,7 +219,7 @@ describe('nonSpec interface', () => {
     // we can mint up to MAX_SUPPLY tokens
     expect(() => {
       let limit = nonSpec.MAX_SUPPLY
-      while(limit-- > 0) {
+      while (limit-- > 0) {
         nonSpec.mint_to(alice)
       }
     }).not.toThrow()

--- a/contracts/rust/Cargo.lock
+++ b/contracts/rust/Cargo.lock
@@ -7,12 +7,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
-name = "ahash"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
-
-[[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,17 +45,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30f3fd65922359a7c6e791bc9b2bba1b977ea0c0b96a528ac48007f535fb4184"
 dependencies = [
- "borsh-derive 0.7.1",
-]
-
-[[package]]
-name = "borsh"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a26c53ddf60281f18e7a29b20db7ba3db82a9d81b9650bfaa02d646f50d364"
-dependencies = [
- "borsh-derive 0.8.0",
- "hashbrown",
+ "borsh-derive",
 ]
 
 [[package]]
@@ -70,21 +54,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2d74755d937d261d5e9bdef87e0addfbc1ace0214f7776f21532d6e97325356"
 dependencies = [
- "borsh-derive-internal 0.7.1",
- "borsh-schema-derive-internal 0.7.1",
- "syn",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808ecd1275d0599d6cb4d8306a3ca53edbeb359f3845d30a37fee25177847bf5"
-dependencies = [
- "borsh-derive-internal 0.8.0",
- "borsh-schema-derive-internal 0.8.0",
- "proc-macro-crate",
- "proc-macro2",
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
  "syn",
 ]
 
@@ -100,32 +71,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh-derive-internal"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a18462b4fef7f552406490667c4f7c6a904ee4e793e4a51b843ac34ba0e984"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "borsh-schema-derive-internal"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5df2543b56ebc2b4493e70d024ebde2cbb48d97bf7b1a16318eff30bd02669b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de92107330c4b204bf02cc224c28ceda5de82a088bbeccc58a00050ceae27d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -185,9 +134,6 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "indexmap"
@@ -273,7 +219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7247d658c51447ea3cd6e86ea55131cf85d17a40f844fc22a0699346ba2fd93"
 dependencies = [
  "base64",
- "borsh 0.7.1",
+ "borsh",
  "bs58",
  "near-runtime-fees",
  "near-sdk-macros",
@@ -313,7 +259,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f19df432b87ae827e1b9dbe557c51cfee24fbc992e72dc5b23d61bbe44c43133"
 dependencies = [
- "borsh 0.7.1",
+ "borsh",
  "near-rpc-error-macro",
  "serde",
 ]
@@ -339,7 +285,7 @@ dependencies = [
 name = "nep4-rs"
 version = "0.1.0"
 dependencies = [
- "borsh 0.8.1",
+ "borsh",
  "near-sdk",
  "serde",
  "serde_json",
@@ -394,15 +340,6 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -494,15 +431,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.61"
 near-sdk = "2.0.1"
-borsh = "0.8.1"
+borsh = "0.7.1"
 wee_alloc = "0.4.5"
 
 [profile.release]


### PR DESCRIPTION
assemblyscript tests fails because `Property 'setPredecessor_account_id' does not exist on type '~lib/near-sdk-core/contract/Context'.`

fixed by changing to `VMContext`

fix rust tests by downgrading borsh

passing tests confirmed by Travis here: https://travis-ci.com/github/petersalomonsen/NFT/builds/214264944