### PR TITLE
fix: make build.sh cd to correct dir, with chmod+x

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-cd ../"`dirname $0`"
+cd "`dirname $0`"/..
 source scripts/flags.sh
 cargo build --all --target wasm32-unknown-unknown --release
 cp target/wasm32-unknown-unknown/release/*.wasm ./res/


### PR DESCRIPTION
It seems after commit https://github.com/near-examples/NFT/commit/f53a01fe55f028bfa81ab6ac35be11cbe86885d4, the build.sh no longer runs for:
1. the `cd` command has a wrong arg
2. the file doesn't have permission to execute

Here's my fix.