### PR TITLE
Adjust contract to allow ABI generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,9 @@ overflow-checks = true
 
 [workspace]
 # remember to include a member for each contract
-members = [
-  "nft",
-  "test-approval-receiver",
-  "test-token-receiver",
-]
-exclude  = [
-  "integration-tests"
-]
+members = ["nft", "test-approval-receiver", "test-token-receiver"]
+exclude = ["integration-tests"]
+
+[patch.crates-io]
+near-sdk = { git = "https://github.com/near/near-sdk-rs", branch = "austin/nft_jschema" }
+near-contract-standards = { git = "https://github.com/near/near-sdk-rs", branch = "austin/nft_jschema" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,3 @@ overflow-checks = true
 # remember to include a member for each contract
 members = ["nft", "test-approval-receiver", "test-token-receiver"]
 exclude = ["integration-tests"]
-
-[patch.crates-io]
-near-sdk = { git = "https://github.com/near/near-sdk-rs", branch = "austin/nft_jschema" }
-near-contract-standards = { git = "https://github.com/near/near-sdk-rs", branch = "austin/nft_jschema" }

--- a/integration-tests/rs/Cargo.toml
+++ b/integration-tests/rs/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2018"
 
 [dev-dependencies]
-near-sdk = "4.0.0"
+near-sdk = "4.1.0-pre.3"
 anyhow = "1.0"
 borsh = "0.9"
 maplit = "1.0"

--- a/nft/Cargo.toml
+++ b/nft/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "4.0.0"
-near-contract-standards = "4.0.0"
+near-sdk = { version = "4.1.0-pre.2", features = ["abi"] }
+near-contract-standards = { version = "4.1.0-pre.2", features = ["abi"] }

--- a/nft/Cargo.toml
+++ b/nft/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { version = "4.1.0-pre.2", features = ["abi"] }
-near-contract-standards = { version = "4.1.0-pre.2", features = ["abi"] }
+near-sdk = { version = "4.1.0-pre.3", features = ["abi"] }
+near-contract-standards = { version = "4.1.0-pre.3", features = ["abi"] }

--- a/nft/src/lib.rs
+++ b/nft/src/lib.rs
@@ -95,7 +95,9 @@ impl Contract {
         receiver_id: AccountId,
         token_metadata: TokenMetadata,
     ) -> Token {
-        self.tokens.mint(token_id, receiver_id, Some(token_metadata))
+        assert_eq!(env::predecessor_account_id(), self.tokens.owner_id, "Unauthorized");
+
+        self.tokens.internal_mint(token_id, receiver_id, Some(token_metadata))
     }
 }
 

--- a/test-approval-receiver/Cargo.toml
+++ b/test-approval-receiver/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "4.0.0"
-near-contract-standards = "4.0.0"
+near-sdk = "4.1.0-pre.2"
+near-contract-standards = "4.1.0-pre.2"

--- a/test-approval-receiver/Cargo.toml
+++ b/test-approval-receiver/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "4.1.0-pre.2"
-near-contract-standards = "4.1.0-pre.2"
+near-sdk = "4.1.0-pre.3"
+near-contract-standards = "4.1.0-pre.3"

--- a/test-token-receiver/Cargo.toml
+++ b/test-token-receiver/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "4.0.0"
-near-contract-standards = "4.0.0"
+near-sdk = "4.1.0-pre.2"
+near-contract-standards = "4.1.0-pre.2"

--- a/test-token-receiver/Cargo.toml
+++ b/test-token-receiver/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "4.1.0-pre.2"
-near-contract-standards = "4.1.0-pre.2"
+near-sdk = "4.1.0-pre.3"
+near-contract-standards = "4.1.0-pre.3"


### PR DESCRIPTION
Used for contract templates. I don't have privileges to push to near-examples but if this can't come in because we want to point to a non pre-release, would be nice to be able to push to a branch that we can link to from the template