### PR TITLE
Patch manifests to fix yanked crate secp256k1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ members = [
 exclude  = [
   "integration-tests"
 ]
+
+# This can be removed when near-sdk is updated
+# Unfortuantely, this crate was yanked by the author and this is needed
+[patch.crates-io]
+parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1.git' }

--- a/integration-tests/rs/Cargo.toml
+++ b/integration-tests/rs/Cargo.toml
@@ -21,3 +21,8 @@ pkg-config = "0.3.1"
 [[example]]
 name = "integration-tests"
 path = "src/tests.rs"
+
+# This can be removed when near-sdk is updated
+# Unfortuantely, this crate was yanked by the author and this is needed
+[patch.crates-io]
+parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1.git' }

--- a/nft/Cargo.toml
+++ b/nft/Cargo.toml
@@ -10,3 +10,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 near-sdk = "4.1.1"
 near-contract-standards = "4.1.1"
+
+# This can be removed when near-sdk is updated
+# Unfortuantely, this crate was yanked by the author and this is needed
+[patch.crates-io]
+parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1.git' }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.69"
+channel = "1.70"

--- a/test-approval-receiver/Cargo.toml
+++ b/test-approval-receiver/Cargo.toml
@@ -10,3 +10,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 near-sdk = "4.1.1"
 near-contract-standards = "4.1.1"
+
+# This can be removed when near-sdk is updated
+# Unfortuantely, this crate was yanked by the author and this is needed
+[patch.crates-io]
+parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1.git' }

--- a/test-token-receiver/Cargo.toml
+++ b/test-token-receiver/Cargo.toml
@@ -10,3 +10,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 near-sdk = "4.1.1"
 near-contract-standards = "4.1.1"
+
+# This can be removed when near-sdk is updated
+# Unfortuantely, this crate was yanked by the author and this is needed
+[patch.crates-io]
+parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1.git' }


### PR DESCRIPTION
Also minor version update to toolchain file to squash issue.

Seems like testing (workspaces) is still messed up, but this PR is to make sure we can get this puppy building again and unblocked for devs, hackers, and partners. Fixes #217 